### PR TITLE
Handle errors during S3 GetObject

### DIFF
--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -199,13 +199,17 @@ class S3RandomAccessFile : public RandomAccessFile {
     });
     auto getObjectOutcome = this->s3_client_->GetObject(getObjectRequest);
     if (!getObjectOutcome.IsSuccess()) {
-      n = 0;
-      *result = StringPiece(scratch, n);
-      return Status(error::OUT_OF_RANGE, "Read less bytes than requested");
+      auto error = getObjectOutcome.GetError();
+      if (error.GetResponseCode() == Aws::Http::HttpResponseCode::REQUESTED_RANGE_NOT_SATISFIABLE) {
+        n = 0;
+        *result = StringPiece(scratch, n);
+        return Status(error::OUT_OF_RANGE, "Read less bytes than requested");
+      } else {
+        return Status(error::UNKNOWN, error.GetExceptionName(), error.GetMessage());
+      }
     }
     n = getObjectOutcome.GetResult().GetContentLength();
     getObjectOutcome.GetResult().GetBody().read(scratch, n);
-
     *result = StringPiece(scratch, n);
     return Status::OK();
   }

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -205,7 +205,7 @@ class S3RandomAccessFile : public RandomAccessFile {
         *result = StringPiece(scratch, n);
         return Status(error::OUT_OF_RANGE, "Read less bytes than requested");
       } else {
-        return Status(error::UNKNOWN, error.GetExceptionName(), error.GetMessage());
+        return errors::Unknown(error.GetExceptionName(), error.GetMessage());
       }
     }
     n = getObjectOutcome.GetResult().GetContentLength();

--- a/tensorflow/core/platform/s3/s3_file_system.h
+++ b/tensorflow/core/platform/s3/s3_file_system.h
@@ -103,7 +103,7 @@ class RetryingS3FileSystem : public RetryingFileSystem<S3FileSystem> {
                     10 /* max_retries */,
                     { error::UNAVAILABLE, error::DEADLINE_EXCEEDED, 
                       error::UNKNOWN, error::FAILED_PRECONDITION,
-                      error::INTERNAL})) {}
+                      error::INTERNAL, error::NOT_FOUND })) {}
 };
 
 }  // namespace tensorflow

--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -609,11 +609,11 @@ def tf_workspace(path_prefix = "", tf_repo_name = ""):
     tf_http_archive(
         name = "aws",
         build_file = clean_dep("//third_party:aws.BUILD"),
-        sha256 = "b888d8ce5fc10254c3dd6c9020c7764dd53cf39cf011249d0b4deda895de1b7c",
-        strip_prefix = "aws-sdk-cpp-1.3.15",
+        sha256 = "89905075fe50aa13e0337ff905c2e8c1ce9caf77a3504484a7cda39179120ffc",
+        strip_prefix = "aws-sdk-cpp-1.5.8",
         urls = [
-            "https://mirror.bazel.build/github.com/aws/aws-sdk-cpp/archive/1.3.15.tar.gz",
-            "https://github.com/aws/aws-sdk-cpp/archive/1.3.15.tar.gz",
+            "https://mirror.bazel.build/github.com/aws/aws-sdk-cpp/archive/1.5.8.tar.gz",
+            "https://github.com/aws/aws-sdk-cpp/archive/1.5.8.tar.gz",
         ],
     )
 

--- a/third_party/aws.BUILD
+++ b/third_party/aws.BUILD
@@ -83,6 +83,11 @@ cc_library(
     deps = [
         "@curl",
     ],
+    copts = [
+        "-DAWS_SDK_VERSION_MAJOR=1", 
+        "-DAWS_SDK_VERSION_MINOR=5", 
+        "-DAWS_SDK_VERSION_PATCH=8"
+    ],
 )
 
 template_rule(


### PR DESCRIPTION
- Raise errors::Unknown when we hit any error code that is not 416. We then rely on RetryingFileSystem introduced in AWS S3 patch/PR to retry those cases.
- For 416, we just return the earlier out of range error.

- Adding error::NotFound is unrelated. But on reviewing some other operations we might have to retry that too. For example, when listing a file which which is not seen by some S3 servers because of eventual consistency issues. It helps to retry instead of crashing.