### PR TITLE
S3 improvements for r1.14

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -3615,6 +3615,34 @@ cc_library(
     alwayslink = 0,
 )
 
+cc_library(
+    name = "retrying_utils",
+    srcs = [
+        "platform/retrying_utils.cc",
+    ],
+    hdrs = [
+        "platform/retrying_utils.h",
+    ],
+    copts = tf_copts(),
+    deps = [
+        "//tensorflow/core:framework_headers_lib",
+        "//tensorflow/core:lib_internal",
+    ],
+)
+
+cc_library(
+    name = "retrying_file_system",
+    hdrs = [
+        "platform/retrying_file_system.h",
+    ],
+    copts = tf_copts(),
+    deps = [
+        ":retrying_utils",
+        "//tensorflow/core:framework_headers_lib",
+        "//tensorflow/core:lib_internal",
+    ],
+)
+
 # -----------------------------------------------------------------------------
 # Tests
 
@@ -5320,6 +5348,32 @@ tf_cc_tests(
         "//tensorflow/cc:client_session",
         "//tensorflow/cc:function_ops",
         "//tensorflow/cc:ops",
+    ],
+)
+
+tf_cc_test(
+    name = "retrying_file_system_test",
+    size = "small",
+    srcs = ["platform/retrying_file_system_test.cc"],
+    deps = [
+        ":retrying_file_system",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+    ],
+)
+
+tf_cc_test(
+    name = "retrying_utils_test",
+    size = "small",
+    srcs = ["platform/retrying_utils_test.cc"],
+    deps = [
+        "//tensorflow/core:retrying_utils",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
     ],
 )
 

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -2455,6 +2455,7 @@ cc_library(
             "platform/**/human_readable_json.cc",
             "platform/abi.cc",
             "platform/protobuf.cc",
+            "platform/retrying_utils.cc"
         ],
     ) + tf_additional_lib_srcs(
         exclude = [

--- a/tensorflow/core/platform/cloud/BUILD
+++ b/tensorflow/core/platform/cloud/BUILD
@@ -83,8 +83,8 @@ cc_library(
         ":google_auth_provider",
         ":http_request",
         ":ram_file_block_cache",
-        ":retrying_file_system",
-        ":retrying_utils",
+        "//tensorflow/core:retrying_file_system",
+        "//tensorflow/core:retrying_utils",
         ":time_util",
         "//tensorflow/core:framework_headers_lib",
         "//tensorflow/core:lib",
@@ -148,7 +148,7 @@ cc_library(
     deps = [
         ":compute_engine_metadata_client",
         ":oauth_client",
-        ":retrying_utils",
+        "//tensorflow/core:retrying_utils",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "@com_google_absl//absl/strings",
@@ -169,7 +169,7 @@ cc_library(
     deps = [
         ":curl_http_request",
         ":http_request",
-        ":retrying_utils",
+        "//tensorflow/core:retrying_utils",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
     ],
@@ -222,34 +222,6 @@ cc_library(
         "//tensorflow/core:lib_internal",
         "@boringssl//:crypto",
         "@jsoncpp_git//:jsoncpp",
-    ],
-)
-
-cc_library(
-    name = "retrying_utils",
-    srcs = [
-        "retrying_utils.cc",
-    ],
-    hdrs = [
-        "retrying_utils.h",
-    ],
-    copts = tf_copts(),
-    deps = [
-        "//tensorflow/core:framework_headers_lib",
-        "//tensorflow/core:lib_internal",
-    ],
-)
-
-cc_library(
-    name = "retrying_file_system",
-    hdrs = [
-        "retrying_file_system.h",
-    ],
-    copts = tf_copts(),
-    deps = [
-        ":retrying_utils",
-        "//tensorflow/core:framework_headers_lib",
-        "//tensorflow/core:lib_internal",
     ],
 )
 
@@ -413,37 +385,11 @@ tf_cc_test(
 )
 
 tf_cc_test(
-    name = "retrying_file_system_test",
-    size = "small",
-    srcs = ["retrying_file_system_test.cc"],
-    deps = [
-        ":retrying_file_system",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
-        "//tensorflow/core:test",
-        "//tensorflow/core:test_main",
-    ],
-)
-
-tf_cc_test(
     name = "time_util_test",
     size = "small",
     srcs = ["time_util_test.cc"],
     deps = [
         ":time_util",
-        "//tensorflow/core:test",
-        "//tensorflow/core:test_main",
-    ],
-)
-
-tf_cc_test(
-    name = "retrying_utils_test",
-    size = "small",
-    srcs = ["retrying_utils_test.cc"],
-    deps = [
-        ":retrying_utils",
-        "//tensorflow/core:lib",
-        "//tensorflow/core:lib_internal",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
     ],

--- a/tensorflow/core/platform/cloud/compute_engine_metadata_client.cc
+++ b/tensorflow/core/platform/cloud/compute_engine_metadata_client.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <utility>
 #include "tensorflow/core/platform/cloud/curl_http_request.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 
 namespace tensorflow {
 

--- a/tensorflow/core/platform/cloud/compute_engine_metadata_client.h
+++ b/tensorflow/core/platform/cloud/compute_engine_metadata_client.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/cloud/http_request.h"
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 
 namespace tensorflow {
 

--- a/tensorflow/core/platform/cloud/gcs_file_system.cc
+++ b/tensorflow/core/platform/cloud/gcs_file_system.cc
@@ -38,7 +38,7 @@ limitations under the License.
 #include "tensorflow/core/platform/cloud/file_block_cache.h"
 #include "tensorflow/core/platform/cloud/google_auth_provider.h"
 #include "tensorflow/core/platform/cloud/ram_file_block_cache.h"
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 #include "tensorflow/core/platform/cloud/time_util.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/mutex.h"

--- a/tensorflow/core/platform/cloud/gcs_file_system.h
+++ b/tensorflow/core/platform/cloud/gcs_file_system.h
@@ -29,7 +29,7 @@ limitations under the License.
 #include "tensorflow/core/platform/cloud/gcs_dns_cache.h"
 #include "tensorflow/core/platform/cloud/gcs_throttle.h"
 #include "tensorflow/core/platform/cloud/http_request.h"
-#include "tensorflow/core/platform/cloud/retrying_file_system.h"
+#include "tensorflow/core/platform/retrying_file_system.h"
 #include "tensorflow/core/platform/file_system.h"
 
 namespace tensorflow {

--- a/tensorflow/core/platform/cloud/google_auth_provider.cc
+++ b/tensorflow/core/platform/cloud/google_auth_provider.cc
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/lib/strings/base64.h"
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 #include "tensorflow/core/platform/env.h"
 
 namespace tensorflow {

--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -105,14 +105,6 @@ int ParseInteger(const char* str, size_t size) {
   return level;
 }
 
-// Parse log level (int64) from environment variable (char*)
-int64 LogLevelStrToInt(const char* tf_env_var_val) {
-  if (tf_env_var_val == nullptr) {
-    return 0;
-  }
-  return ParseInteger(tf_env_var_val, strlen(tf_env_var_val));
-}
-
 // Using StringPiece breaks Windows build.
 struct StringData {
   struct Hasher {
@@ -181,6 +173,14 @@ VmoduleMap* VmodulesMapFromEnv() {
 }
 
 }  // namespace
+
+// Parse log level (int64) from environment variable (char*)
+int64 LogLevelStrToInt(const char* tf_env_var_val) {
+  if (tf_env_var_val == nullptr) {
+    return 0;
+  }
+  return ParseInteger(tf_env_var_val, strlen(tf_env_var_val));
+}
 
 int64 MinLogLevelFromEnv() {
   // We don't want to print logs during fuzzing as that would slow fuzzing down

--- a/tensorflow/core/platform/default/logging.cc
+++ b/tensorflow/core/platform/default/logging.cc
@@ -105,6 +105,14 @@ int ParseInteger(const char* str, size_t size) {
   return level;
 }
 
+// Parse log level (int64) from environment variable (char*)
+int64 LogLevelStrToInt(const char* tf_env_var_val) {
+  if (tf_env_var_val == nullptr) {
+    return 0;
+  }
+  return ParseInteger(tf_env_var_val, strlen(tf_env_var_val));
+}
+
 // Using StringPiece breaks Windows build.
 struct StringData {
   struct Hasher {
@@ -173,14 +181,6 @@ VmoduleMap* VmodulesMapFromEnv() {
 }
 
 }  // namespace
-
-// Parse log level (int64) from environment variable (char*)
-int64 LogLevelStrToInt(const char* tf_env_var_val) {
-  if (tf_env_var_val == nullptr) {
-    return 0;
-  }
-  return ParseInteger(tf_env_var_val, strlen(tf_env_var_val));
-}
 
 int64 MinLogLevelFromEnv() {
   // We don't want to print logs during fuzzing as that would slow fuzzing down

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -336,6 +336,8 @@ T&& CheckNotNull(const char* file, int line, const char* exprtext, T&& t) {
   return std::forward<T>(t);
 }
 
+int64 LogLevelStrToInt(const char* tf_env_var_val);
+
 int64 MinLogLevelFromEnv();
 
 int64 MinVLogLevelFromEnv();

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -336,8 +336,6 @@ T&& CheckNotNull(const char* file, int line, const char* exprtext, T&& t) {
   return std::forward<T>(t);
 }
 
-int64 LogLevelStrToInt(const char* tf_env_var_val);
-
 int64 MinLogLevelFromEnv();
 
 int64 MinVLogLevelFromEnv();

--- a/tensorflow/core/platform/env.cc
+++ b/tensorflow/core/platform/env.cc
@@ -258,6 +258,12 @@ Status Env::IsDirectory(const string& fname) {
   return fs->IsDirectory(fname);
 }
 
+Status Env::NeedsTempLocation(const string& path) {
+  FileSystem* fs;
+  TF_RETURN_IF_ERROR(GetFileSystemForFile(path, &fs));
+  return fs->NeedsTempLocation(path);
+}
+
 Status Env::DeleteRecursively(const string& dirname, int64* undeleted_files,
                               int64* undeleted_dirs) {
   FileSystem* fs;

--- a/tensorflow/core/platform/env.h
+++ b/tensorflow/core/platform/env.h
@@ -221,6 +221,15 @@ class Env {
   ///  * UNIMPLEMENTED - The file factory doesn't support directories.
   Status IsDirectory(const string& fname);
 
+  /// \brief Returns whether the given path needs a temp location
+  /// to safely write objects.
+  /// Typical return codes (not guaranteed exhaustive):
+  ///  * OK - The path is on a file system that should use a temp location
+  ///         to safely write objects
+  ///  * FAILED_PRECONDITION - The path is on a file system that does not
+  ///            need a temp location
+  Status NeedsTempLocation(const string& path);
+
   /// Stores the size of `fname` in `*file_size`.
   Status GetFileSize(const string& fname, uint64* file_size);
 

--- a/tensorflow/core/platform/file_system.cc
+++ b/tensorflow/core/platform/file_system.cc
@@ -47,6 +47,10 @@ Status FileSystem::IsDirectory(const string& name) {
   return Status(tensorflow::error::FAILED_PRECONDITION, "Not a directory");
 }
 
+Status FileSystem::NeedsTempLocation(const string& path) {
+  return Status::OK();
+}
+
 void FileSystem::FlushCaches() {}
 
 RandomAccessFile::~RandomAccessFile() {}

--- a/tensorflow/core/platform/file_system.h
+++ b/tensorflow/core/platform/file_system.h
@@ -220,6 +220,14 @@ class FileSystem {
   ///  * UNIMPLEMENTED - The file factory doesn't support directories.
   virtual Status IsDirectory(const string& fname);
 
+  /// \brief Returns whether the given path needs a temp location to write
+  /// safely
+  ///
+  /// Typical return codes (not guaranteed exhaustive):
+  ///  * OK - Needs a temp location
+  ///  * FAILED_PRECONDITION - Does not need a temp location
+  virtual Status NeedsTempLocation(const string& path);
+
   /// \brief Flushes any cached filesystem objects from memory.
   virtual void FlushCaches();
 

--- a/tensorflow/core/platform/file_system_test.cc
+++ b/tensorflow/core/platform/file_system_test.cc
@@ -261,6 +261,12 @@ TEST(InterPlanetaryFileSystemTest, RecursivelyCreateAlreadyExistingDir) {
   TF_EXPECT_OK(ipfs.RecursivelyCreateDir(dirname));
 }
 
+TEST(InterPlanetaryFileSystemTest, NeedsTempLocation) {
+  InterPlanetaryFileSystem ipfs;
+  const string dirname = io::JoinPath(kPrefix, "match-00/abc/00");
+  TF_EXPECT_OK(ipfs.NeedsTempLocation(dirname));
+}
+
 // A simple file system with a root directory and a single file underneath it.
 class TestFileSystem : public NullFileSystem {
  public:

--- a/tensorflow/core/platform/retrying_file_system.h
+++ b/tensorflow/core/platform/retrying_file_system.h
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/lib/random/random.h"
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/file_system.h"
 
@@ -119,6 +119,11 @@ class RetryingFileSystem : public FileSystem {
     return RetryingUtils::CallWithRetries(
         [this, &dirname]() { return base_file_system_->IsDirectory(dirname); },
         retry_config_);
+  }
+
+  Status NeedsTempLocation(const string& path) override {
+    // this does not need to be retried
+    return base_file_system_->NeedsTempLocation(path);
   }
 
   Status DeleteRecursively(const string& dirname, int64* undeleted_files,

--- a/tensorflow/core/platform/retrying_file_system_test.cc
+++ b/tensorflow/core/platform/retrying_file_system_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/platform/cloud/retrying_file_system.h"
+#include "tensorflow/core/platform/retrying_file_system.h"
 #include <fstream>
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/lib/strings/str_util.h"

--- a/tensorflow/core/platform/retrying_utils.h
+++ b/tensorflow/core/platform/retrying_utils.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <functional>
 #include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/core/errors.h"
 
 namespace tensorflow {
 
@@ -25,10 +26,14 @@ namespace tensorflow {
 struct RetryConfig {
   RetryConfig(int64 init_delay_time_us = 100 * 1000,
               int64 max_delay_time_us = 32 * 1000 * 1000,
-              int max_retries = 10) {
+              int max_retries = 10,
+              std::set<error::Code> retriable_errors = {error::UNAVAILABLE, 
+                error::DEADLINE_EXCEEDED,
+                error::UNKNOWN}) {
     this->init_delay_time_us = init_delay_time_us;
     this->max_delay_time_us = max_delay_time_us;
     this->max_retries = max_retries;
+    this->retriable_errors = retriable_errors;
   }
 
   // In case of failure, every call will be retried max_retries times.
@@ -39,6 +44,9 @@ struct RetryConfig {
 
   // Maximum backoff time in microseconds.
   int64 max_delay_time_us;
+
+  // Set of errors which need to be retried
+  std::set<error::Code> retriable_errors;
 };
 
 class RetryingUtils {

--- a/tensorflow/core/platform/retrying_utils_test.cc
+++ b/tensorflow/core/platform/retrying_utils_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/platform/cloud/retrying_utils.h"
+#include "tensorflow/core/platform/retrying_utils.h"
 #include <fstream>
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/lib/strings/str_util.h"

--- a/tensorflow/core/platform/s3/aws_crypto.cc
+++ b/tensorflow/core/platform/s3/aws_crypto.cc
@@ -15,6 +15,7 @@ limitations under the License.
 #include "tensorflow/core/platform/s3/aws_crypto.h"
 #include <openssl/hmac.h>
 #include <openssl/sha.h>
+#include <openssl/rand.h>
 
 #include <aws/core/utils/crypto/HashResult.h>
 #include <aws/s3/S3Client.h>
@@ -100,6 +101,22 @@ class AWSSha256OpenSSLImpl : public Aws::Utils::Crypto::Hash {
   }
 };
 
+class AWSSecureRandomBytesImpl : public Aws::Utils::Crypto::SecureRandomBytes {
+ public:
+  AWSSecureRandomBytesImpl() {}
+  virtual ~AWSSecureRandomBytesImpl() = default;
+  virtual void GetBytes(unsigned char* buffer, size_t bufferSize) override {
+    assert(buffer);
+    int success = RAND_bytes(buffer, static_cast<int>(bufferSize));
+    if (success != 1) {
+      m_failure = true;
+    }
+  }
+
+ private:
+  bool m_failure;
+};
+
 std::shared_ptr<Aws::Utils::Crypto::Hash>
 AWSSHA256Factory::CreateImplementation() const {
   return Aws::MakeShared<AWSSha256OpenSSLImpl>(AWSCryptoAllocationTag);
@@ -108,6 +125,11 @@ AWSSHA256Factory::CreateImplementation() const {
 std::shared_ptr<Aws::Utils::Crypto::HMAC>
 AWSSHA256HmacFactory::CreateImplementation() const {
   return Aws::MakeShared<AWSSha256HMACOpenSSLImpl>(AWSCryptoAllocationTag);
+}
+
+std::shared_ptr<Aws::Utils::Crypto::SecureRandomBytes>
+AWSSecureRandomFactory::CreateImplementation() const {
+  return Aws::MakeShared<AWSSecureRandomBytesImpl>(AWSCryptoAllocationTag);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/s3/aws_crypto.h
+++ b/tensorflow/core/platform/s3/aws_crypto.h
@@ -16,6 +16,7 @@ limitations under the License.
 #include <aws/core/utils/crypto/Factories.h>
 #include <aws/core/utils/crypto/HMAC.h>
 #include <aws/core/utils/crypto/Hash.h>
+#include <aws/core/utils/crypto/SecureRandom.h>
 
 namespace tensorflow {
 static const char* AWSCryptoAllocationTag = "AWSCryptoAllocation";
@@ -29,6 +30,12 @@ class AWSSHA256Factory : public Aws::Utils::Crypto::HashFactory {
 class AWSSHA256HmacFactory : public Aws::Utils::Crypto::HMACFactory {
  public:
   std::shared_ptr<Aws::Utils::Crypto::HMAC> CreateImplementation()
+      const override;
+};
+
+class AWSSecureRandomFactory : public Aws::Utils::Crypto::SecureRandomFactory {
+ public:
+  std::shared_ptr<Aws::Utils::Crypto::SecureRandomBytes> CreateImplementation()
       const override;
 };
 

--- a/tensorflow/core/platform/s3/aws_logging.cc
+++ b/tensorflow/core/platform/s3/aws_logging.cc
@@ -63,7 +63,7 @@ void AWSLogSystem::LogMessage(Aws::Utils::Logging::LogLevel log_level,
       LOG(FATAL) << message;
       break;
     default:
-      LOG(ERROR) << message;
+      LOG(INFO) << message;
       break;
   }
 }
@@ -91,26 +91,38 @@ static const char* kAWSLoggingTag = "AWSLogging";
 
 Aws::Utils::Logging::LogLevel ParseLogLevelFromEnv() {
   Aws::Utils::Logging::LogLevel log_level = Aws::Utils::Logging::LogLevel::Info;
-
-  const int64_t level = getenv("AWS_LOG_LEVEL")
-                            ? LogLevelStrToInt(getenv("AWS_LOG_LEVEL"))
-                            : tensorflow::internal::MinLogLevelFromEnv();
-
+  const char* aws_sdk_log = std::getenv("TF_S3_LOG_LEVEL");
+  int64_t level;
+  if (aws_sdk_log == nullptr) {
+    // default logging level of FATAL
+    level = 1;
+  } else {
+    level = tensorflow::internal::LogLevelStrToInt(aws_sdk_log);
+  }
   switch (level) {
-    case INFO:
-      log_level = Aws::Utils::Logging::LogLevel::Info;
+    case 0:
+      log_level = Aws::Utils::Logging::LogLevel::Off;
       break;
-    case WARNING:
-      log_level = Aws::Utils::Logging::LogLevel::Warn;
-      break;
-    case ERROR:
-      log_level = Aws::Utils::Logging::LogLevel::Error;
-      break;
-    case FATAL:
+    case 1:
       log_level = Aws::Utils::Logging::LogLevel::Fatal;
       break;
-    default:
+    case 2:
+      log_level = Aws::Utils::Logging::LogLevel::Error;
+      break;
+    case 3:
+      log_level = Aws::Utils::Logging::LogLevel::Warn;
+      break;
+    case 4:
       log_level = Aws::Utils::Logging::LogLevel::Info;
+      break;
+    case 5:
+      log_level = Aws::Utils::Logging::LogLevel::Debug;
+      break;
+    case 6:
+      log_level = Aws::Utils::Logging::LogLevel::Trace;
+      break;
+    default:
+      log_level = Aws::Utils::Logging::LogLevel::Fatal;
       break;
   }
 

--- a/tensorflow/core/platform/s3/aws_logging.cc
+++ b/tensorflow/core/platform/s3/aws_logging.cc
@@ -97,7 +97,7 @@ Aws::Utils::Logging::LogLevel ParseLogLevelFromEnv() {
     // default logging level of FATAL
     level = 1;
   } else {
-    level = tensorflow::internal::LogLevelStrToInt(aws_sdk_log);
+    level = LogLevelStrToInt(aws_sdk_log);
   }
   switch (level) {
     case 0:

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -662,7 +662,7 @@ Status S3FileSystem::DeleteDir(const string& dirname) {
         (contents.size() == 1 && contents[0].GetKey() != prefix.c_str())) {
       // Due to Eventual consistency of S3, list may return the objects even after the deletes above
       // to retry this operation in such case, the error type has been changed to Errors::Internal
-      return errors::INTERNAL("Cannot delete a non-empty directory.");
+      return errors::Internal("Cannot delete a non-empty directory.");
     }
     if (contents.size() == 1 && contents[0].GetKey() == prefix.c_str()) {
       string filename = dirname;

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -202,7 +202,7 @@ class S3RandomAccessFile : public RandomAccessFile {
 
   Status Read(uint64 offset, size_t n, StringPiece* result,
               char* scratch) const override {
-    VLOG(1) << "ReadFilefromS3 s3://" << bucket_ << "/" << object_;
+    VLOG(1) << "ReadFilefromS3 s3://" << bucket_ << "/" << object_ << " from " << offset << " for n:" << n;
     Aws::S3::Model::GetObjectRequest getObjectRequest;
     getObjectRequest.WithBucket(bucket_.c_str()).WithKey(object_.c_str());
     string bytes = strings::StrCat("bytes=", offset, "-", offset + n - 1);
@@ -488,6 +488,7 @@ Status S3FileSystem::FileExists(const string& fname) {
 
 Status S3FileSystem::GetChildren(const string& dir,
                                  std::vector<string>* result) {
+  VLOG(1) << "GetChildren for path: " << dir;
   string bucket, prefix;
   TF_RETURN_IF_ERROR(ParseS3Path(dir, false, &bucket, &prefix));
 
@@ -537,7 +538,7 @@ Status S3FileSystem::GetChildren(const string& dir,
 Status S3FileSystem::Stat(const string& fname, FileStatistics* stats) {
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, true, &bucket, &object));
-
+  VLOG(1) << "Stat on path: " << fname;
   if (object.empty()) {
     Aws::S3::Model::HeadBucketRequest headBucketRequest;
     headBucketRequest.WithBucket(bucket.c_str());
@@ -600,7 +601,7 @@ Status S3FileSystem::GetMatchingPaths(const string& pattern,
 Status S3FileSystem::DeleteFile(const string& fname) {
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, false, &bucket, &object));
-
+  VLOG(1) << "DeleteFile: " << fname;
   Aws::S3::Model::DeleteObjectRequest deleteObjectRequest;
   deleteObjectRequest.WithBucket(bucket.c_str()).WithKey(object.c_str());
 
@@ -616,7 +617,7 @@ Status S3FileSystem::DeleteFile(const string& fname) {
 Status S3FileSystem::CreateDir(const string& dirname) {
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(dirname, true, &bucket, &object));
-
+  VLOG(1) << "CreateDir: " << dirname;
   if (object.empty()) {
     Aws::S3::Model::HeadBucketRequest headBucketRequest;
     headBucketRequest.WithBucket(bucket.c_str());
@@ -659,7 +660,9 @@ Status S3FileSystem::DeleteDir(const string& dirname) {
     auto contents = listObjectsOutcome.GetResult().GetContents();
     if (contents.size() > 1 ||
         (contents.size() == 1 && contents[0].GetKey() != prefix.c_str())) {
-      return errors::FailedPrecondition("Cannot delete a non-empty directory.");
+      // Due to Eventual consistency of S3, list may return the objects even after the deletes above
+      // to retry this operation in such case, the error type has been changed to Errors::Internal
+      return errors::INTERNAL("Cannot delete a non-empty directory.");
     }
     if (contents.size() == 1 && contents[0].GetKey() == prefix.c_str()) {
       string filename = dirname;

--- a/tensorflow/core/platform/s3/s3_file_system.cc
+++ b/tensorflow/core/platform/s3/s3_file_system.cc
@@ -443,7 +443,8 @@ Status S3FileSystem::NewAppendableFile(const string& fname,
 
   string bucket, object;
   TF_RETURN_IF_ERROR(ParseS3Path(fname, false, &bucket, &object));
-  result->reset(new S3WritableFile(bucket, object, this->GetS3Client()));
+  result->reset(new S3WritableFile(bucket, object, this->GetTransferManager(),
+				    this->GetS3Client()));
 
   while (true) {
     status = reader->Read(offset, kS3ReadAppendableFileBufferSize, &read_chunk,

--- a/tensorflow/core/platform/s3/s3_file_system.h
+++ b/tensorflow/core/platform/s3/s3_file_system.h
@@ -103,7 +103,7 @@ class RetryingS3FileSystem : public RetryingFileSystem<S3FileSystem> {
                 100000 /* init_delay_time_us */,
                 32000000 /* max_delay_time_us */, 10 /* max_retries */,
                 {error::UNAVAILABLE, error::DEADLINE_EXCEEDED, error::UNKNOWN,
-                 error::FAILED_PRECONDITION, error::INTERNAL})) {}
+                 error::INTERNAL})) {}
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/platform/s3/s3_file_system_test.cc
+++ b/tensorflow/core/platform/s3/s3_file_system_test.cc
@@ -231,5 +231,11 @@ TEST_F(S3FileSystemTest, StatFile) {
   EXPECT_FALSE(stat.is_directory);
 }
 
+TEST_F(S3FileSystemTest, NeedsTempLocation) {
+  const string fname = TmpDir("NeedsTempLocation");
+  TF_ASSERT_OK(WriteString(fname, "test"));
+  EXPECT_EQ(error::Code::FAILED_PRECONDITION, s3fs.NeedsTempLocation(fname).code());
+}
+
 }  // namespace
 }  // namespace tensorflow

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle.cc
@@ -23,8 +23,8 @@ limitations under the License.
 
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.pb.h"
-#include "tensorflow/core/framework/tensor_shape.pb_text.h"
 #include "tensorflow/core/framework/tensor_shape.pb.h"
+#include "tensorflow/core/framework/tensor_shape.pb_text.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/framework/types.pb_text.h"
 #include "tensorflow/core/framework/variant.h"
@@ -41,6 +41,7 @@ limitations under the License.
 #include "tensorflow/core/lib/io/path.h"
 #include "tensorflow/core/lib/io/table_builder.h"
 #include "tensorflow/core/lib/random/random.h"
+#include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/lib/strings/stringprintf.h"
 #include "tensorflow/core/util/saved_tensor_slice_util.h"
 #include "tensorflow/core/util/tensor_slice_util.h"
@@ -390,24 +391,30 @@ BundleWriter::BundleWriter(Env* env, StringPiece prefix, const Options& options)
     : env_(env),
       options_(options),
       prefix_(prefix),
-      tmp_metadata_path_(strings::StrCat(MetaFilename(prefix_), ".tempstate",
-                                         random::New64())),
-      tmp_data_path_(strings::StrCat(DataFilename(prefix_, 0, 1), ".tempstate",
-                                     random::New64())),
       out_(nullptr),
       size_(0) {
+  data_path_ = DataFilename(prefix_, 0, 1);
+  metadata_path_ = MetaFilename(prefix_);
+  use_temp_file_ = env_->NeedsTempLocation(prefix_).ok();
+  if (use_temp_file_) {
+    data_path_ = strings::StrCat(data_path_, ".tempstate", random::New64());
+    metadata_path_ =
+      strings::StrCat(metadata_path_, ".tempstate", random::New64());
+  }
+  
   status_ = env_->CreateDir(string(io::Dirname(prefix_)));
   if (!status_.ok() && !errors::IsAlreadyExists(status_)) {
     return;
   }
-  const string filename = DataFilename(prefix_, 0, 1);
+  
   std::unique_ptr<WritableFile> wrapper;
-  status_ = env_->NewWritableFile(tmp_data_path_, &wrapper);
+
+  status_ = env_->NewWritableFile(data_path_, &wrapper);
   if (!status_.ok()) return;
   out_ = std::unique_ptr<FileOutputBuffer>(
       new FileOutputBuffer(wrapper.release(), 8 << 20 /* 8MB write buffer */));
 
-  VLOG(1) << "Writing to file " << tmp_data_path_;
+  VLOG(1) << "Writing to file " << data_path_;
 }
 
 Status BundleWriter::Add(StringPiece key, const Tensor& val) {
@@ -495,16 +502,18 @@ Status BundleWriter::Finish() {
     status_.Update(out_->Close());
     out_ = nullptr;
     if (status_.ok()) {
-      status_ = Env::Default()->RenameFile(tmp_data_path_,
-                                           DataFilename(prefix_, 0, 1));
+      if (use_temp_file_) {
+        status_ =
+          Env::Default()->RenameFile(data_path_, DataFilename(prefix_, 0, 1));
+      }
     } else {
-      Env::Default()->DeleteFile(tmp_data_path_).IgnoreError();
+      Env::Default()->DeleteFile(data_path_).IgnoreError();
     }
   }
   if (!status_.ok()) return status_;
   // Build key -> BundleEntryProto table.
   std::unique_ptr<WritableFile> file;
-  status_ = env_->NewWritableFile(tmp_metadata_path_, &file);
+  status_ = env_->NewWritableFile(metadata_path_, &file);
   if (!status_.ok()) return status_;
   {
     // N.B.: the default use of Snappy compression may not be supported on all
@@ -531,12 +540,14 @@ Status BundleWriter::Finish() {
   }
   status_.Update(file->Close());
   if (!status_.ok()) {
-    Env::Default()->DeleteFile(tmp_metadata_path_).IgnoreError();
+    Env::Default()->DeleteFile(metadata_path_).IgnoreError();
     return status_;
   } else {
-    status_ =
-        Env::Default()->RenameFile(tmp_metadata_path_, MetaFilename(prefix_));
-    if (!status_.ok()) return status_;
+    if (use_temp_file_) {
+      status_ = 
+        Env::Default()->RenameFile(metadata_path_, MetaFilename(prefix_));
+      if (!status_.ok()) return status_;
+    }
   }
   status_ = errors::Internal("BundleWriter is closed");
   return Status::OK();

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle.h
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle.h
@@ -149,8 +149,9 @@ class BundleWriter {
   Env* const env_;  // Not owned.
   const Options options_;
   const string prefix_;
-  const string tmp_metadata_path_;
-  const string tmp_data_path_;
+  string metadata_path_;
+  string data_path_;
+  bool use_temp_file_;
   std::unique_ptr<FileOutputBuffer> out_;
   int64 size_;  // Number of bytes written into out_.
   std::map<string, BundleEntryProto> entries_;

--- a/tensorflow/python/lib/io/file_io.i
+++ b/tensorflow/python/lib/io/file_io.i
@@ -163,6 +163,19 @@ bool IsDirectory(const string& dirname, TF_Status* out_status) {
   return false;
 }
 
+bool NeedsTempLocation(const string& path, TF_Status* out_status) {
+  tensorflow::Status status = tensorflow::Env::Default()->NeedsTempLocation(path);
+  if (status.ok()) {
+    return true;
+  }
+  // FAILED_PRECONDITION Status response means that writing to the path
+  // does not need a temp location
+  if (status.code() != tensorflow::error::FAILED_PRECONDITION) {
+    Set_TF_Status_from_Status(out_status, status);
+  }
+  return false;
+}
+
 using tensorflow::FileStatistics;
 
 void Stat(const string& filename, FileStatistics* stats, TF_Status* status) {
@@ -261,6 +274,7 @@ void RenameFile(const string& oldname, const string& newname, bool overwrite,
                 TF_Status* status);
 void DeleteRecursively(const string& dirname, TF_Status* status);
 bool IsDirectory(const string& dirname, TF_Status* out_status);
+bool NeedsTempLocation(const string& path, TF_Status* out_status);
 void Stat(const string& filename, tensorflow::FileStatistics* stats,
           TF_Status* status);
 tensorflow::io::BufferedInputStream* CreateBufferedInputStream(

--- a/tensorflow/python/platform/gfile.py
+++ b/tensorflow/python/platform/gfile.py
@@ -27,6 +27,7 @@ from tensorflow.python.lib.io.file_io import file_exists as Exists
 from tensorflow.python.lib.io.file_io import FileIO as _FileIO
 from tensorflow.python.lib.io.file_io import get_matching_files as Glob
 from tensorflow.python.lib.io.file_io import is_directory as IsDirectory
+from tensorflow.python.lib.io.file_io import needs_temp_location as NeedsTempLocation
 from tensorflow.python.lib.io.file_io import list_directory as ListDirectory
 from tensorflow.python.lib.io.file_io import recursive_create_dir as MakeDirs
 from tensorflow.python.lib.io.file_io import rename as Rename

--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -38,12 +38,15 @@ from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import device as pydev
 from tensorflow.python.framework import errors
+from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import meta_graph
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_io_ops
 from tensorflow.python.ops import io_ops
+from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import state_ops
 from tensorflow.python.ops import string_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import gfile
@@ -247,7 +250,9 @@ class BaseSaverBuilder(object):
     # prefix directly, instead of any physical pathname.  (On failure and
     # subsequent restore, an outdated and orphaned temporary directory can be
     # safely removed.)
-    _SHARDED_SUFFIX = "_temp_%s/part" % uuid.uuid4().hex
+    _SHARDED_SUFFIX = control_flow_ops.cond(string_ops.regex_full_match(checkpoint_prefix, '^s3://.*'),
+                                            lambda: ".part",
+                                            lambda: "_temp_%s/part" % uuid.uuid4().hex)
     tmp_checkpoint_prefix = string_ops.string_join(
         [checkpoint_prefix, _SHARDED_SUFFIX])
 

--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -250,9 +250,10 @@ class BaseSaverBuilder(object):
     # prefix directly, instead of any physical pathname.  (On failure and
     # subsequent restore, an outdated and orphaned temporary directory can be
     # safely removed.)
-    _SHARDED_SUFFIX = control_flow_ops.cond(string_ops.regex_full_match(checkpoint_prefix, '^s3://.*'),
-                                            lambda: ".part",
-                                            lambda: "_temp_%s/part" % uuid.uuid4().hex)
+    _SHARDED_SUFFIX = control_flow_ops.cond(
+      string_ops.regex_full_match(checkpoint_prefix, '^s3://.*'),
+        lambda: ".part",
+        lambda: "_temp_%s/part" % uuid.uuid4().hex)
     tmp_checkpoint_prefix = string_ops.string_join(
         [checkpoint_prefix, _SHARDED_SUFFIX])
 

--- a/tensorflow/python/training/saving/functional_saver.py
+++ b/tensorflow/python/training/saving/functional_saver.py
@@ -206,12 +206,11 @@ class MultiDeviceSaver(object):
     # prefix directly, instead of any physical pathname.  (On failure and
     # subsequent restore, an outdated and orphaned temporary directory can be
     # safely removed.)
-    sharded_suffix = control_flow_ops.cond(
-      string_ops.regex_full_match(file_prefix, '^s3://.*'), 
-        lambda: ".part",
-        lambda: "_temp_%s/part" % uuid.uuid4().hex)
-
     with ops.device("cpu:0"):
+      sharded_suffix = control_flow_ops.cond(
+        string_ops.regex_full_match(file_prefix, '^s3://.*'), 
+          lambda: ".part",
+          lambda: "_temp_%s/part" % uuid.uuid4().hex)
       tmp_checkpoint_prefix = string_ops.string_join(
           [file_prefix, sharded_suffix])
 

--- a/tensorflow/python/training/saving/functional_saver.py
+++ b/tensorflow/python/training/saving/functional_saver.py
@@ -33,7 +33,7 @@ from tensorflow.python.ops import string_ops
 from tensorflow.python.training.saving import saveable_object
 from tensorflow.python.training.saving import saveable_object_util
 from tensorflow.python.util import nest
-
+from tensorflow.python.ops import control_flow_ops
 
 class _SingleDeviceSaver(object):
   """Saves and restores checkpoints from the current device."""
@@ -206,7 +206,10 @@ class MultiDeviceSaver(object):
     # prefix directly, instead of any physical pathname.  (On failure and
     # subsequent restore, an outdated and orphaned temporary directory can be
     # safely removed.)
-    sharded_suffix = "_temp_%s/part" % uuid.uuid4().hex
+    sharded_suffix = control_flow_ops.cond(
+      string_ops.regex_full_match(file_prefix, '^s3://.*'), 
+        lambda: ".part",
+        lambda: "_temp_%s/part" % uuid.uuid4().hex)
 
     with ops.device("cpu:0"):
       tmp_checkpoint_prefix = string_ops.string_join(

--- a/tensorflow/tools/api/golden/v1/tensorflow.gfile.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.gfile.pbtxt
@@ -60,4 +60,8 @@ tf_module {
     name: "Walk"
     argspec: "args=[\'top\', \'in_order\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
+  member_method {
+    name: "NeedsTempLocation"
+    argspec: "args=[\'path\'], varargs=None, keywords=None, defaults=None"
+  }
 }

--- a/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.io.gfile.pbtxt
@@ -52,4 +52,8 @@ tf_module {
     name: "walk"
     argspec: "args=[\'top\', \'topdown\', \'onerror\'], varargs=None, keywords=None, defaults=[\'True\', \'None\'], "
   }
+  member_method {
+    name: "needstemp"
+    argspec: "args=[\'path\'], varargs=None, keywords=None, defaults=None"
+  }
 }

--- a/third_party/aws/BUILD.bazel
+++ b/third_party/aws/BUILD.bazel
@@ -53,6 +53,8 @@ cc_library(
         "aws-cpp-sdk-kinesis/source/**/*.cpp",
         "aws-cpp-sdk-s3/include/**/*.h",
         "aws-cpp-sdk-s3/source/**/*.cpp",
+        "aws-cpp-sdk-transfer/include/**/*.h",
+        "aws-cpp-sdk-transfer/source/**/*.cpp",
     ]),
     hdrs = [
         "aws-cpp-sdk-core/include/aws/core/SDKConfig.h",
@@ -84,6 +86,7 @@ cc_library(
         "aws-cpp-sdk-core/include/",
         "aws-cpp-sdk-kinesis/include/",
         "aws-cpp-sdk-s3/include/",
+        "aws-cpp-sdk-transfer/include/",
     ],
     deps = [
         "@curl",


### PR DESCRIPTION
**Usability:**
- Adds an environment variable TF_S3_LOG_LEVEL to control the logging information from S3 operations. 
  - By default, this level is set to 1, which only logs fatal errors. This removes the flood of unnecessary logs that are thrown when using S3 currently which stem from improper usage of AWS_CPP_SDK logging levels. 
  - User can change the level when necessary using the following values: 0 (OFF), 1 (FATAL), 2 (ERROR), 3 (WARNING), 4 (INFO), 5 (DEBUG), 6 (TRACE)

**Reliability**
S3 supports an [eventual consistency model](https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel), which does not work like a regular file system. This means that many operations currently in the s3 file system crash now and then because the conditions it expects are not satisfied by S3. The following changes tries to address such crashes. 

- _Skip usage of temp file when writing to S3:_
  When writing a file to S3, the file system currently writes a temp file locally and syncs at the end by creating a file on S3. This coupled with the fact that S3 provides atomic uploads of files means that we will never see incomplete data uploaded for a file. In this scenario, the current usage of temp files when writing anything to the s3 file system (such as for Checkpoints, SavedModels) are unnecessary. I've removed such usage of temp files for S3 as they not just are unnecessary but cause issues with S3's consistency model. (It may so happen that after writing to a temp file, the file is not visible while moving to final location because changes haven't propagated yet. )

- _Skip usage of temp directory when saving Checkpoints and SavedModels to S3:_ 
  When saving Checkpoints and SavedModels, there is also the use of a temp directory where all files are uploaded and then moved to the final location. This is even more problematic given S3's eventual consistency model. This sequence of operations involves the writing to temp location, listing of files in temp location, copying each file from this temp location to final location, and deleting the temp location. There are multiple issues users have experienced because of this sequence. When listing files in temp directory, in some cases not all files show up in the list. This causes some files to not be copied. While deleting directory, there is another listing of all files in the directory. Again this list may be inconsistent and the deleting of directory fails. So the usage of such temp directory has been bypassed for S3 file system.

- The above two changes have been implemented by introducing a NeedsTempLocation method for the filesystem and exposing it to python through gfile similar to how IsDirectory works. This method needs to be used multiple places both in python and CPP. By default for any file system other than S3, it returns False, which allows us to skip the usage of temp locations. The above issues for Checkpointing and SavedModels have been addressed and verified for both code paths of Estimator based training, Session based training as well as Keras. 

- _Retry failed operations before crashing:_
  It is recommended to use retries to handle exceptions in the case of unexpected errors due to the eventual consistency paradigm. Moved the class retrying_file_system from `platform/cloud` to `platform/` and reused that for S3 file system.

- Fixed a bug in the file system where it treated failures as if it had reached the end of file when reading files from S3.

- Upgraded the AWS SDK as the SDK has some fixes for bugs we ran into.

**Reliability and Performance**
- _Use TransferManager from the AWS CPP SDK to upload files to S3_ 
Using PUT for uploads as is done currently has a few limitations. It doesn't allow the upload of files larger than 5GB which in our experience, users have run into. It also doesn't retry in the case of crashes. Using the TransferManager allows us to upload larger files, upload files faster by using multi-part upload, and retry only the failed parts in case of crashes.


  | Time to upload 2GB | Time to upload 4GB | Time to upload 5.5GB
-- | -- | -- | --
Official Tensorflow r1.12 | 103 sec | 116 sec | Crash: Entity too large
Tensorflow 1.12 with S3 patch | 9 sec | 20 sec | 28 sec
Speedup | 11x | 6x |  

